### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
-EasyUI KEYWORD1
+EasyUI	KEYWORD1
 
-detectCDN KEYWORD2
-title KEYWORD2
-begin KEYWORD2
-label KEYWORD2
-toggleButton KEYWORD2
-loop KEYWORD2
+detectCDN	KEYWORD2
+title	KEYWORD2
+begin	KEYWORD2
+label	KEYWORD2
+toggleButton	KEYWORD2
+loop	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords