### PR TITLE
add missing ArduinoJson dependency in library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,11 +17,18 @@
     }
   ],
   "dependencies":
-  {
-    "name": "ESP Async WebServer",
-    "authors": "Hristo Gochkov",
-    "frameworks": "arduino"
-  },
+  [
+    {
+      "name": "ESP Async WebServer",
+      "authors": "Hristo Gochkov",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "ArduinoJson",
+      "authors": "Benoit Blanchon",
+      "frameworks": "arduino"
+    }
+  ],
   "version": "1.5.4",
   "frameworks": "arduino",
   "platforms": "*"


### PR DESCRIPTION
ArduinoJson is not listed as a dependency in library.json. This obviously leads to compilation errors. So here's a small fix for this issue. Now it's sufficient to specify ESPUI as a "lib_deps" in PlatformIO's platformio.ini and the necessary dependencies are automatically pulled in.