### PR TITLE
Force version 5 ArudinoJson

### DIFF
--- a/library.json
+++ b/library.json
@@ -22,6 +22,7 @@
     },
     {
       "name": "ArduinoJson",
+      "version": "5.13.4",
       "authors": "Benoit Blanchon",
       "frameworks": "arduino"
     }


### PR DESCRIPTION
When using PIO to auto download libraries, the latest v6 json is used, so forcing v5 is required