### PR TITLE
Fix support for ESP32 LittleFS in ESP-IDF 4.4/ESP32 Arduino Core 2.0.0 and later, fixes issue #179 etc.

### DIFF
--- a/examples/prepareFilesystem/prepareFilesystem.ino
+++ b/examples/prepareFilesystem/prepareFilesystem.ino
@@ -3,7 +3,12 @@
 void setup(void)
 {
   Serial.begin(115200);
-  ESPUI.prepareFileSystem();
+  ESPUI.setVerbosity(Verbosity::Verbose); //Enable verbose output so you see the files in LittleFS
+  delay(500); //Delay to allow Serial Monitor to start after a reset
+  Serial.println(F("\nPreparing filesystem with ESPUI resources"));
+  ESPUI.prepareFileSystem();  //Copy across current version of ESPUI resources
+  Serial.println(F("Done, files..."));
+  ESPUI.list(); //List all files on LittleFS, for info
 }
 
 void loop()

--- a/keywords.txt
+++ b/keywords.txt
@@ -25,6 +25,7 @@ beginLITTLEFS	KEYWORD2
 print	KEYWORD2
 updateSwitcher	KEYWORD2
 updateSlider	KEYWORD2
+list	KEYWORD2
 captivePortal	LITERAL1
 
 #######################################

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -11,7 +11,11 @@
 #if defined(ESP32)
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
-#include <LITTLEFS.h>
+#if (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4) || ESP_IDF_VERSION_MAJOR > 4
+	#include <LittleFS.h>
+#else
+	#include <LITTLEFS.h>
+#endif
 
 #include "WiFi.h"
 
@@ -246,8 +250,7 @@ public:
     void beginLITTLEFS(const char* _title, const char* username = nullptr, const char* password = nullptr,
         uint16_t port = 80); // Setup server and page in LITTLEFS mode
 
-    void prepareFileSystem(); // Initially preps the filesystem and loads a lot of
-                              // stuff into LITTLEFS
+    void prepareFileSystem(bool format = true); // Initially preps the filesystem and loads a lot of stuff into LITTLEFS
     void list(); // Lists LITTLEFS directory
 
     uint16_t addControl(ControlType type, const char* label);


### PR DESCRIPTION
Hi there, I've done a conditional refactor for LittleFS related code on ESP32. The refactor only applies if ESP-IDF 4.4 and later is in use, so should not break for people still using older versions.

Tested on ESP32 (Arduino core 2.05, 2.0.0 and 1.06), ESP32-S2 (Arduino core 2.05 and 2.0.0) and ESP8266 (Arduino core 3.02).

I have also made ESPUI.list() function the same on ESP8266 as it does on ESP32 and added it to keywords.txt and made the prepareFilesystem.ino sketch more verbose to give feedback to the user.

Known issue with this PR: Formatting LittleFS in ESPUI.prepareFilesystem() on ESP32 causes a crash which I can't find a resolution to so it is commented out for now. The 'format if not mounted' fallback logic seems to work fine.

I hope this proves useful, any problems/suggestions/changes let me know.