### PR TITLE
Several LittleFS changes, fixes #192, adds option to not format LittleFS

### DIFF
--- a/examples/prepareFilesystem/prepareFilesystem.ino
+++ b/examples/prepareFilesystem/prepareFilesystem.ino
@@ -3,7 +3,12 @@
 void setup(void)
 {
   Serial.begin(115200);
-  ESPUI.prepareFileSystem();
+  ESPUI.setVerbosity(Verbosity::Verbose); //Enable verbose output so you see the files in LittleFS
+  delay(500); //Delay to allow Serial Monitor to start after a reset
+  Serial.println(F("\nPreparing filesystem with ESPUI resources"));
+  ESPUI.prepareFileSystem();  //Copy across current version of ESPUI resources
+  Serial.println(F("Done, files..."));
+  ESPUI.list(); //List all files on LittleFS, for info
 }
 
 void loop()

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -7,7 +7,11 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <stdlib_noniso.h>
-#include <LittleFS.h>
+#if (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4) || ESP_IDF_VERSION_MAJOR > 4
+	#include <LittleFS.h>
+#else
+	#include <LITTLEFS.h>
+#endif
 #include <map>
 #include <ESPAsyncWebServer.h>
 

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -104,7 +104,7 @@ public:
     void beginLITTLEFS(const char* _title, const char* username = nullptr, const char* password = nullptr,
         uint16_t port = 80); // Setup server and page in LITTLEFS mode
 
-    void prepareFileSystem(); // Initially preps the filesystem and loads a lot of
+    void prepareFileSystem(bool format = true); // Initially preps the filesystem and loads a lot of
                               // stuff into LITTLEFS
     void list(); // Lists LITTLEFS directory
 

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -7,10 +7,14 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <stdlib_noniso.h>
-#if (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4) || ESP_IDF_VERSION_MAJOR > 4
-	#include <LittleFS.h>
+#ifdef ESP32
+	#if (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4) || ESP_IDF_VERSION_MAJOR > 4
+		#include <LittleFS.h>
+	#else
+		#include <LITTLEFS.h>
+	#endif
 #else
-	#include <LITTLEFS.h>
+	#include <LittleFS.h>
 #endif
 #include <map>
 #include <ESPAsyncWebServer.h>


### PR DESCRIPTION
Fix formatting related exception on using prepareFileSystem() on ESP32
Add the option to _not_ format LittleFS when using prepareFileSystem (very minor new feature)
Fix adding of files to LittleFS with prepareFileSystem() on ESP32, was missing mkdir for directories
Add LittleFS backward compatibility for ESP-IDF prior to v4.4/Arduino core 2.0 on ESP32
Make ListDir work recursively on ESP8266
Change filesystem sizes displayed in ListDir to KB and added some labels to the figures
Tested on ESP8266 (Arduino core 3.02) and ESP32 (Arduino core 1.0.6 & 2.0.5)