### PR TITLE
pointers can always be casted to long

### DIFF
--- a/examples/gui-generic-api/gui-generic-api.ino
+++ b/examples/gui-generic-api/gui-generic-api.ino
@@ -57,7 +57,7 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(int(param)));
+    Serial.println(String("param: ") + String(long(param)));
     switch (type)
     {
     case B_DOWN:

--- a/examples/gui/gui.ino
+++ b/examples/gui/gui.ino
@@ -62,7 +62,7 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(int(param)));
+    Serial.println(String("param: ") + String(long(param)));
     switch (type)
     {
     case B_DOWN:

--- a/examples/tabbedGui/tabbedGui.ino
+++ b/examples/tabbedGui/tabbedGui.ino
@@ -56,7 +56,7 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(int(param)));
+    Serial.println(String("param: ") + String(long(param)));
     switch (type)
     {
     case B_DOWN:

--- a/pio_examples/gui/src/gui.ino
+++ b/pio_examples/gui/src/gui.ino
@@ -62,7 +62,7 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(int(param)));
+    Serial.println(String("param: ") + String(long(param)));
     switch (type)
     {
     case B_DOWN:


### PR DESCRIPTION
When compiling in emulation mode (on host, 64 bits compiler), this proposal fixes the following error:
```cpp
.../libraries/ESPUI/examples/gui/gui.ino: In function ‘void buttonExample(Control*, int, void*)’:
.../libraries/ESPUI/examples/gui/gui.ino:65:47: error: cast from ‘void*’ to ‘int’ loses precision [-fpermissive]
   65 |     Serial.println(String("param: ") + String(int(param)));
      |                                               ^~~~~~~~~~
```

fixes #217
#217 is also fixed by https://github.com/d-a-v/emuAsync/pull/2