### PR TITLE
reduce memory footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ ESPUI includes a range of advanced features that can customise your UIs.
 
 ### Dynamic Visibility
 
-Cotrols can be made visible or invisible at runtime with the `updateVisibility()` function.
+Controls can be made visible or invisible at runtime with the `updateVisibility()` function.
 
 ```
 ESPUI.updateVisibility(controlId, false);

--- a/examples/completeExample/completeExample.cpp
+++ b/examples/completeExample/completeExample.cpp
@@ -26,8 +26,18 @@
 #include <WiFi.h>
 #include <ESPmDNS.h>
 #else
+// esp8266
 #include <ESP8266WiFi.h>
 #include <ESP8266mDNS.h>
+#include <umm_malloc/umm_heap_select.h>
+#ifndef MMU_IRAM_HEAP
+#warning Try MMU option '2nd heap shared' in 'tools' IDE menu (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#option-summary)
+#warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
+#warning then check http://<ip>/heap
+#endif // MMU_IRAM_HEAP
+#ifndef DEBUG_ESP_OOM
+#error on ESP8266 and ESPUI, you must define OOM debug option when developping
+#endif
 #endif
 
 //Settings
@@ -62,6 +72,11 @@ volatile bool updates = false;
 
 // This is the main function which builds our GUI
 void setUpUI() {
+
+#ifdef ESP8266
+    { HeapSelectIram doAllocationsInIRAM;
+#endif
+
 	//Turn off verbose debugging
 	ESPUI.setVerbosity(Verbosity::Quiet);
 
@@ -274,6 +289,11 @@ void setUpUI() {
 	//Finally, start up the UI. 
 	//This should only be called once we are connected to WiFi.
 	ESPUI.begin(HOSTNAME);
+
+#ifdef ESP8266
+    } // HeapSelectIram
+#endif
+
 }
 
 //This callback generates and applies inline styles to a bunch of controls to change their colour.

--- a/examples/completeExample/completeExample.ino
+++ b/examples/completeExample/completeExample.ino
@@ -1,0 +1,1 @@
+// placeholder

--- a/examples/gui-generic-api/gui-generic-api.ino
+++ b/examples/gui-generic-api/gui-generic-api.ino
@@ -8,7 +8,17 @@ DNSServer dnsServer;
 #if defined(ESP32)
 #include <WiFi.h>
 #else
+// esp8266
 #include <ESP8266WiFi.h>
+#include <umm_malloc/umm_heap_select.h>
+#ifndef MMU_IRAM_HEAP
+#warning Try MMU option '2nd heap shared' in 'tools' IDE menu (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#option-summary)
+#warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
+#warning then check http://<ip>/heap
+#endif // MMU_IRAM_HEAP
+#ifndef DEBUG_ESP_OOM
+#error on ESP8266 and ESPUI, you must define OOM debug option when developping
+#endif
 #endif
 
 const char* ssid = "ESPUI";
@@ -235,6 +245,10 @@ void setup(void)
     Serial.print("IP address: ");
     Serial.println(WiFi.getMode() == WIFI_AP ? WiFi.softAPIP() : WiFi.localIP());
 
+#ifdef ESP8266
+    { HeapSelectIram doAllocationsInIRAM;
+#endif
+
     status = ESPUI.addControl(ControlType::Label, "Status:", "Stop", ControlColor::Turquoise);
 
     uint16_t select1 = ESPUI.addControl(
@@ -281,6 +295,10 @@ void setup(void)
      */
 
     ESPUI.begin("ESPUI Control");
+
+#ifdef ESP8266
+    } // HeapSelectIram
+#endif
 }
 
 void loop(void)

--- a/examples/gui/gui.ino
+++ b/examples/gui/gui.ino
@@ -8,7 +8,17 @@ DNSServer dnsServer;
 #if defined(ESP32)
 #include <WiFi.h>
 #else
+// esp8266
 #include <ESP8266WiFi.h>
+#include <umm_malloc/umm_heap_select.h>
+#ifndef MMU_IRAM_HEAP
+#warning Try MMU option '2nd heap shared' in 'tools' IDE menu (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#option-summary)
+#warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
+#warning then check http://<ip>/heap
+#endif // MMU_IRAM_HEAP
+#ifndef DEBUG_ESP_OOM
+#error on ESP8266 and ESPUI, you must define OOM debug option when developping
+#endif
 #endif
 
 const char* ssid = "ESPUI";
@@ -225,6 +235,10 @@ void setup(void)
     Serial.print("IP address: ");
     Serial.println(WiFi.getMode() == WIFI_AP ? WiFi.softAPIP() : WiFi.localIP());
 
+#ifdef ESP8266
+    { HeapSelectIram doAllocationsInIRAM;
+#endif
+
     statusLabelId = ESPUI.label("Status:", ControlColor::Turquoise, "Stop");
     millisLabelId = ESPUI.label("Millis:", ControlColor::Emerald, "0");
     ESPUI.button("Push Button", &buttonCallback, ControlColor::Peterriver, "Press");
@@ -257,6 +271,10 @@ void setup(void)
      * password, for example begin("ESPUI Control", "username", "password")
      */
     ESPUI.begin("ESPUI Control");
+
+#ifdef ESP8266
+    } // HeapSelectIram
+#endif
 }
 
 void loop(void)

--- a/examples/tabbedGui/tabbedGui.ino
+++ b/examples/tabbedGui/tabbedGui.ino
@@ -8,7 +8,17 @@ DNSServer dnsServer;
 #if defined(ESP32)
 #include <WiFi.h>
 #else
+// esp8266
 #include <ESP8266WiFi.h>
+#include <umm_malloc/umm_heap_select.h>
+#ifndef MMU_IRAM_HEAP
+#warning Try MMU option '2nd heap shared' in 'tools' IDE menu (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#option-summary)
+#warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
+#warning then check http://<ip>/heap
+#endif // MMU_IRAM_HEAP
+#ifndef DEBUG_ESP_OOM
+#error on ESP8266 and ESPUI, you must define OOM debug option when developping
+#endif
 #endif
 
 const char* ssid = "ESPUI";
@@ -233,6 +243,10 @@ void setup(void)
     Serial.print("IP address: ");
     Serial.println(WiFi.getMode() == WIFI_AP ? WiFi.softAPIP() : WiFi.localIP());
 
+#ifdef ESP8266
+    { HeapSelectIram doAllocationsInIRAM;
+#endif
+
     uint16_t tab1 = ESPUI.addControl(ControlType::Tab, "Settings 1", "Settings 1");
     uint16_t tab2 = ESPUI.addControl(ControlType::Tab, "Settings 2", "Settings 2");
     uint16_t tab3 = ESPUI.addControl(ControlType::Tab, "Settings 3", "Settings 3");
@@ -279,6 +293,10 @@ void setup(void)
      */
 
     ESPUI.begin("ESPUI Control");
+
+#ifdef ESP8266
+    } // HeapSelectIram
+#endif
 }
 
 void loop(void)

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -98,8 +98,13 @@ public:
 #endif // def ESP32
 
     unsigned int jsonUpdateDocumentSize = 2000;
+#ifdef ESP8266
+    unsigned int jsonInitialDocumentSize = 2000;
+    unsigned int jsonChunkNumberMax = 5;
+#else
     unsigned int jsonInitialDocumentSize = 8000;
     unsigned int jsonChunkNumberMax = 0;
+#endif
     bool sliderContinuous = false;
     void onWsEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 	bool captivePortal = true;

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -87,20 +87,20 @@ enum Verbosity : uint8_t
 class ESPUIClass
 {
 public:
+
+#ifdef ESP32
     ESPUIClass()
     {
-        verbosity = Verbosity::Quiet;
-        jsonUpdateDocumentSize = 2000;
-        jsonInitialDocumentSize = 8000;
-        sliderContinuous = false;
-#ifdef ESP32
         ControlsSemaphore = xSemaphoreCreateMutex();
         xSemaphoreGive(ControlsSemaphore);
-#endif // def ESP32
     }
-    unsigned int jsonUpdateDocumentSize;
-    unsigned int jsonInitialDocumentSize;
-    bool sliderContinuous;
+    SemaphoreHandle_t ControlsSemaphore = NULL;
+#endif // def ESP32
+
+    unsigned int jsonUpdateDocumentSize = 2000;
+    unsigned int jsonInitialDocumentSize = 8000;
+    unsigned int jsonChunkNumberMax = 0;
+    bool sliderContinuous = false;
     void onWsEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 	bool captivePortal = true;
 
@@ -205,16 +205,12 @@ public:
     void jsonReload();
     void jsonDom(uint16_t startidx, AsyncWebSocketClient* client = nullptr, bool Updating = false);
 
-    Verbosity verbosity;
+    Verbosity verbosity = Verbosity::Quiet;
     AsyncWebServer* server;
 
 protected:
     friend class ESPUIclient;
     friend class ESPUIcontrol;
-
-#ifdef ESP32
-    SemaphoreHandle_t ControlsSemaphore = NULL;
-#endif // def ESP32
 
     void        RemoveToBeDeletedControls();
 


### PR DESCRIPTION
On esp8266, large UIs are too heavy.
This PRs aims at optimizing memory usage:
- `ESPUI.jsonChunkNumberMax = 5`² prevents from filling the whole memory before sending a JSON/Websocket chunk
- proposed internal class `JSONSlave::` makes serialization twice.
  - First time does not write but count number of bytes (it takes time ~2ms, but is worth the shot)
  - Second time is made into a string which has been reserved to this size

With these changes¹, a sketch that was failing into burning pieces gets these number now (`http://url/heap`)
```
IRAM: free: 7352 max: 7240 frag: 2%
DRAM: free: 21768 max: 21608 frag: 1%
In Memorymode
```


¹ and the help of `HeapSelectIram cheatingBlock` in my init function which moves usage of ~7KB from DRAM to IRAM
(but I'd still have had enough room given the remaining free 21KB)

² also with `ESPUI.jsonInitialDocumentSize = 2000` early in my `setup()`