### PR TITLE
minor fixes for restoring warning-less emulation on host 

### DIFF
--- a/examples/completeExample/completeExample.cpp
+++ b/examples/completeExample/completeExample.cpp
@@ -35,7 +35,7 @@
 #warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
 #warning then check http://<ip>/heap
 #endif // MMU_IRAM_HEAP
-#ifndef DEBUG_ESP_OOM
+#if !defined(DEBUG_ESP_OOM) && !defined(CORE_MOCK)
 #error on ESP8266 and ESPUI, you must define OOM debug option when developping
 #endif
 #endif
@@ -396,7 +396,7 @@ void extendedCallback(Control* sender, int type, void* param)
     Serial.print(sender->label);
     Serial.print("' = ");
     Serial.println(sender->value);
-    Serial.println(String("param = ") + String((int)param));
+    Serial.println(String("param = ") + String((long)param));
 }
 
 void setup() {
@@ -443,6 +443,7 @@ void loop() {
 				#if !defined(ESP32)
 					((void (*)())0xf00fdead)();
 				#endif
+				break;
 			default:
 				Serial.print('#');
 				break;

--- a/examples/completeExample/completeExample.cpp
+++ b/examples/completeExample/completeExample.cpp
@@ -396,7 +396,8 @@ void extendedCallback(Control* sender, int type, void* param)
     Serial.print(sender->label);
     Serial.print("' = ");
     Serial.println(sender->value);
-    Serial.println(String("param = ") + String((long)param));
+    Serial.print("param = ");
+    Serial.println((long)param);
 }
 
 void setup() {

--- a/examples/completeExample/completeExample.ino
+++ b/examples/completeExample/completeExample.ino
@@ -1,1 +1,4 @@
 // placeholder
+#if CORE_MOCK
+#include "completeExample.cpp"
+#endif

--- a/examples/gui-generic-api/gui-generic-api.ino
+++ b/examples/gui-generic-api/gui-generic-api.ino
@@ -16,7 +16,7 @@ DNSServer dnsServer;
 #warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
 #warning then check http://<ip>/heap
 #endif // MMU_IRAM_HEAP
-#ifndef DEBUG_ESP_OOM
+#if !defined(DEBUG_ESP_OOM) && !defined(CORE_MOCK)
 #error on ESP8266 and ESPUI, you must define OOM debug option when developping
 #endif
 #endif

--- a/examples/gui-generic-api/gui-generic-api.ino
+++ b/examples/gui-generic-api/gui-generic-api.ino
@@ -67,7 +67,8 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(long(param)));
+    Serial.print("param: ");
+    Serial.println(long(param));
     switch (type)
     {
     case B_DOWN:

--- a/examples/gui/gui.ino
+++ b/examples/gui/gui.ino
@@ -16,7 +16,7 @@ DNSServer dnsServer;
 #warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
 #warning then check http://<ip>/heap
 #endif // MMU_IRAM_HEAP
-#ifndef DEBUG_ESP_OOM
+#if !defined(DEBUG_ESP_OOM) && !defined(CORE_MOCK)
 #error on ESP8266 and ESPUI, you must define OOM debug option when developping
 #endif
 #endif

--- a/examples/gui/gui.ino
+++ b/examples/gui/gui.ino
@@ -72,7 +72,8 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(long(param)));
+    Serial.print("param: ");
+    Serial.println(long(param));
     switch (type)
     {
     case B_DOWN:

--- a/examples/tabbedGui/tabbedGui.ino
+++ b/examples/tabbedGui/tabbedGui.ino
@@ -16,7 +16,7 @@ DNSServer dnsServer;
 #warning use decorators: { HeapSelectIram doAllocationsInIRAM; ESPUI.addControl(...) ... } (cf. https://arduino-esp8266.readthedocs.io/en/latest/mmu.html#how-to-select-heap)
 #warning then check http://<ip>/heap
 #endif // MMU_IRAM_HEAP
-#ifndef DEBUG_ESP_OOM
+#if !defined(DEBUG_ESP_OOM) && !defined(CORE_MOCK)
 #error on ESP8266 and ESPUI, you must define OOM debug option when developping
 #endif
 #endif

--- a/examples/tabbedGui/tabbedGui.ino
+++ b/examples/tabbedGui/tabbedGui.ino
@@ -66,7 +66,8 @@ void buttonCallback(Control* sender, int type)
 
 void buttonExample(Control* sender, int type, void* param)
 {
-    Serial.println(String("param: ") + String(long(param)));
+    Serial.print("param: ");
+    Serial.println(long(param));
     switch (type)
     {
     case B_DOWN:


### PR DESCRIPTION
This is useful
- for debugging (using emuAsync, see main readme)
- because this is part of #249 for easier reviewing

*Additional notes*
- avoiding to use `String + String` when possible saves memory