### PR TITLE
Remove LITTLEFS library

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,7 +26,7 @@
       "frameworks": "arduino"
     }
   ],
-  "version": "2.2.4",
+  "version": "2.2.3",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -24,14 +24,9 @@
       "name": "ArduinoJson",
       "authors": "Benoit Blanchon",
       "frameworks": "arduino"
-    },
-    {
-      "name": "LittleFS_esp32",
-      "authors": "lorol",
-      "frameworks": "arduino"
     }
   ],
-  "version": "2.2.3",
+  "version": "2.2.4",
   "frameworks": "arduino",
   "platforms": "*"
 }


### PR DESCRIPTION
Hi,
since Arduino 2.0.0 is the LITTLEFS library not more required for ESP32.
It will fix the #196 issues.
