### PR TITLE
use more string references

### DIFF
--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -916,7 +916,7 @@ void ESPUIClass::updateControl(Control* control, int)
     NotifyClients(ClientUpdateType_t::UpdateNeeded);
 }
 
-void ESPUIClass::setPanelStyle(uint16_t id, String style, int clientId)
+void ESPUIClass::setPanelStyle(uint16_t id, const String& style, int clientId)
 {
     Control* control = getControl(id);
     if (control)
@@ -926,7 +926,7 @@ void ESPUIClass::setPanelStyle(uint16_t id, String style, int clientId)
     }
 }
 
-void ESPUIClass::setElementStyle(uint16_t id, String style, int clientId)
+void ESPUIClass::setElementStyle(uint16_t id, const String& style, int clientId)
 {
     Control* control = getControl(id);
     if (control)
@@ -936,7 +936,7 @@ void ESPUIClass::setElementStyle(uint16_t id, String style, int clientId)
     }
 }
 
-void ESPUIClass::setInputType(uint16_t id, String type, int clientId)
+void ESPUIClass::setInputType(uint16_t id, const String& type, int clientId)
 {
     Control* control = getControl(id);
     if (control)

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -194,9 +194,9 @@ public:
     void clearGraph(uint16_t id, int clientId = -1);
     void addGraphPoint(uint16_t id, int nValue, int clientId = -1);
 
-    void setPanelStyle(uint16_t id, String style, int clientId = -1);
-    void setElementStyle(uint16_t id, String style, int clientId = -1);
-    void setInputType(uint16_t id, String type, int clientId = -1);
+    void setPanelStyle(uint16_t id, const String& style, int clientId = -1);
+    void setElementStyle(uint16_t id, const String& style, int clientId = -1);
+    void setInputType(uint16_t id, const String& type, int clientId = -1);
 
     void setPanelWide(uint16_t id, bool wide);
     void setVertical(uint16_t id, bool vert = true);


### PR DESCRIPTION
Avoid more memory fragmentation on low-memory environments