### PR TITLE
Add "autoupdate value" option for input controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(includedirs src)
+
+set(req arduino ESPAsyncWebServer ArduinoJson)
+
+idf_component_register(
+	INCLUDE_DIRS ${includedirs} 
+	SRC_DIRS src
+	SRCS ${SOURCES}
+	REQUIRES ${req})

--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -630,7 +630,10 @@ uint16_t ESPUIClass::addControl(ControlType type, const char* label, const Strin
 uint16_t ESPUIClass::addControl(
     ControlType type, const char* label, const String& value, ControlColor color, uint16_t parentControl)
 {
-    return addControl(type, label, value, color, parentControl, new Control(type, label, nullptr, value, color, true, parentControl));
+    Control * ctrl = new Control(type, label, nullptr, value, color, true, parentControl);
+    if (auto_update_values && ctrl)
+        ctrl->auto_update_value = true;
+    return addControl(type, label, value, color, parentControl, ctrl);
 }
 
 uint16_t ESPUIClass::addControl(ControlType type, const char* label, const String& value, ControlColor color,
@@ -1103,7 +1106,7 @@ void ESPUIClass::addGraphPoint(uint16_t id, int nValue, int clientId)
     } while (false);
 }
 
-bool ESPUIClass::SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId)
+bool ESPUIClass::SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, int clientId)
 {
     bool Response = false;
 

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -105,6 +105,7 @@ public:
     bool sliderContinuous = false;
     void onWsEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
 	bool captivePortal = true;
+    bool auto_update_values = false;
 
     void setVerbosity(Verbosity verbosity);
     void begin(const char* _title, const char* username = nullptr, const char* password = nullptr,
@@ -256,7 +257,7 @@ protected:
     void NotifyClients(ClientUpdateType_t newState);
     void NotifyClient(uint32_t WsClientId, ClientUpdateType_t newState);
 
-    bool SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId);
+    bool SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, int clientId);
 
     std::map<uint32_t, ESPUIclient*> MapOfClients;
 

--- a/src/ESPUIcontrol.h
+++ b/src/ESPUIcontrol.h
@@ -62,6 +62,7 @@ public:
     bool wide;
     bool vertical;
     bool enabled;
+    bool auto_update_value;
     uint16_t parentControl;
     String panelStyle;
     String elementStyle;


### PR DESCRIPTION
There is included changes for https://github.com/s00500/ESPUI/issues/270

Usage Notes:

The CMakeLists.txt file is used in the case of using the library as an ESP-IDF component.

If it is necessary for the user input controls to update their values upon user input, then include ESPUI.auto_update_values = true; before calling ESPUI.addControl(). 
This option can also be activated for an already created control by changing Control.auto_update_value