### PR TITLE
Made WebServer and WebSocket globally accusable via access functions.

### DIFF
--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -232,6 +232,9 @@ public:
         return accelerometer(label, [callback, userData](Control* sender, int type){ callback(sender, type, userData); }, color);
     }
 
+    AsyncWebServer* WebServer() {return server;}
+    AsyncWebSocket* WebSocket() {return ws;}
+
 protected:
     friend class ESPUIclient;
     friend class ESPUIcontrol;


### PR DESCRIPTION
WARNING: You must call ESPUI.begin before using the WebServer() or WebSocket() calls.