### PR TITLE
Cleanup of disconnected clients

### DIFF
--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -449,6 +449,11 @@ void ESPUIClass::onWsEvent(
     }
     else
     {
+        if(type == WS_EVT_CONNECT)
+        {
+            ws->cleanupClients();
+        }
+        
         if (MapOfClients.end() == MapOfClients.find(client->id()))
         {
             // Serial.println("ESPUIClass::OnWsEvent:Create new client.");


### PR DESCRIPTION
If a client reloads the page by using `F5` a new connection will be created, but the old one will not trigger a disconnect. This leads into high memory usage and could cause a crash depending on the UI size and amount of reloads.
To trigger a disconnect of old clients the `AsyncWebSocket.cleanupClients()` will now be called on every connect.

#### Debug output before change:
```
UI Initialized
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
1
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
2
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
3
```

#### Debug output after change:
```
UI Initialized
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
1
WS_EVT_DISCONNECT
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
2
WS_EVT_DISCONNECT
ESPUIclient::OnWsEvent:WS_EVT_CONNECT
3
```