### PR TITLE
ArduinoJson 7 support

### DIFF
--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -932,11 +932,11 @@ void ESPUIClass::clearGraph(uint16_t id, int clientId)
             break;
         }
 
-#if ARDUINOJSON_VERSION_MAJOR < 7
-        DynamicJsonDocument document(jsonUpdateDocumentSize);
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
         JsonDocument document;
-#endif      
+#else
+        DynamicJsonDocument document(jsonUpdateDocumentSize);
+#endif    
         JsonObject root = document.to<JsonObject>();
 
         root[F("type")] = (int)ControlType::Graph + UpdateOffset;
@@ -958,10 +958,10 @@ void ESPUIClass::addGraphPoint(uint16_t id, int nValue, int clientId)
             break;
         }
 
-#if ARDUINOJSON_VERSION_MAJOR < 7
-        DynamicJsonDocument document(jsonUpdateDocumentSize);
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
         JsonDocument document;
+#else
+        DynamicJsonDocument document(jsonUpdateDocumentSize);
 #endif
         JsonObject root = document.to<JsonObject>();
 
@@ -974,10 +974,10 @@ void ESPUIClass::addGraphPoint(uint16_t id, int nValue, int clientId)
     } while (false);
 }
 
-#if ARDUINOJSON_VERSION_MAJOR < 7
-bool ESPUIClass::SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId)
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
 bool ESPUIClass::SendJsonDocToWebSocket(ArduinoJson::JsonDocument& document, uint16_t clientId)
+#else
+bool ESPUIClass::SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId)
 #endif
 {
     bool Response = false;

--- a/src/ESPUI.h
+++ b/src/ESPUI.h
@@ -271,15 +271,13 @@ protected:
     void NotifyClients(ClientUpdateType_t newState);
     void NotifyClient(uint32_t WsClientId, ClientUpdateType_t newState);
 
-#if ARDUINOJSON_VERSION_MAJOR < 7
-    bool SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId);
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
     bool SendJsonDocToWebSocket(ArduinoJson::JsonDocument& document, uint16_t clientId);
+#else
+    bool SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document, uint16_t clientId);
 #endif
-
     std::map<uint32_t, ESPUIclient*> MapOfClients;
-
-    uint32_t    ControlChangeID = 0;
+    uint32_t ControlChangeID = 0;
 };
 
 extern ESPUIClass ESPUI;

--- a/src/ESPUIclient.h
+++ b/src/ESPUIclient.h
@@ -43,15 +43,14 @@ protected:
     // bool        NeedsNotification() { return pCurrentFsmState != &fsm_EspuiClient_state_Idle_imp; }
 
     bool        CanSend();
-#if ARDUINOJSON_VERSION_MAJOR < 7
-    void        FillInHeader(ArduinoJson::DynamicJsonDocument& document);
-    uint32_t    prepareJSONChunk(uint16_t startindex, DynamicJsonDocument& rootDoc, bool InUpdateMode, String value);
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
     void        FillInHeader(ArduinoJson::JsonDocument& document);
     uint32_t    prepareJSONChunk(uint16_t startindex, JsonDocument& rootDoc, bool InUpdateMode, String value);
-#endif    
+#else
+    void        FillInHeader(ArduinoJson::DynamicJsonDocument& document);
+    uint32_t    prepareJSONChunk(uint16_t startindex, DynamicJsonDocument& rootDoc, bool InUpdateMode, String value);
+#endif 
     bool        SendControlsToClient(uint16_t startidx, ClientUpdateType_t TransferMode, String FragmentRequest);
-
     bool        SendClientNotification(ClientUpdateType_t value);
 
 private:
@@ -67,9 +66,9 @@ public:
     bool        IsSyncronized();
     uint32_t    id() { return client->id(); }
     void        SetState(ClientUpdateType_t value);
-#if ARDUINOJSON_VERSION_MAJOR < 7
-    bool        SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document);
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
     bool        SendJsonDocToWebSocket(ArduinoJson::JsonDocument& document);
+#else
+    bool        SendJsonDocToWebSocket(ArduinoJson::DynamicJsonDocument& document);
 #endif
 };

--- a/src/ESPUIcontrol.cpp
+++ b/src/ESPUIcontrol.cpp
@@ -82,10 +82,10 @@ void Control::MarshalControl(JsonObject & _item, bool refresh, uint32_t Starting
         _item[F("offset")] = StartingOffset;
         _item[F("length")] = length;
         _item[F("total")] = value.length();
-#if ARDUINOJSON_VERSION_MAJOR < 7
-        item = _item.createNestedObject(F("control"));
-#else
+#if ARDUINOJSON_VERSION_MAJOR > 6
         item = _item["control"].add<JsonObject>();
+#else
+        item = _item.createNestedObject(F("control"));
 #endif
     }
 


### PR DESCRIPTION
Support for ArduinoJson 7 has been added with backward compatibility for older versions  (`>=6.17.0`). 
I've already tested the change with ArduinoJson `v6.17.0` (older will fail as before change) and `v7.0.4` on a `ESP32`. Unfortunately I couldn't test a `ESP8266` because I don't have one available at the moment, but at least the compile works fine.