### PR TITLE
Resolve null pointer exception

### DIFF
--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -531,7 +531,14 @@ uint16_t ESPUIClass::addControl(
 
     NotifyClients(ClientUpdateType_t::RebuildNeeded);
 
-    return control->id;
+    if (control == nullptr)
+    {
+        return 0;
+    }
+    else
+    {
+        return control->id;
+    }
 }
 
 bool ESPUIClass::removeControl(uint16_t id, bool force_rebuild_ui)

--- a/src/ESPUI.cpp
+++ b/src/ESPUI.cpp
@@ -531,14 +531,7 @@ uint16_t ESPUIClass::addControl(
 
     NotifyClients(ClientUpdateType_t::RebuildNeeded);
 
-    if (control == nullptr)
-    {
-        return 0;
-    }
-    else
-    {
-        return control->id;
-    }
+    return control->id;
 }
 
 bool ESPUIClass::removeControl(uint16_t id, bool force_rebuild_ui)
@@ -667,7 +660,7 @@ uint16_t ESPUIClass::gauge(const char* label, ControlColor color, int number, in
 
 uint16_t ESPUIClass::separator(const char* label)
 {
-    return addControl(ControlType::Separator, label, "", ControlColor::Alizarin, Control::noParent, nullptr);
+    return addControl(ControlType::Separator, label, "", ControlColor::Alizarin);
 }
 
 uint16_t ESPUIClass::fileDisplay(const char* label, ControlColor color, String filename)


### PR DESCRIPTION
Adding a separator using `ESPUI.separator("Separator name");` triggers an exception when the code tries to access the property of an invalid object.